### PR TITLE
Busbud changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ If you already have a StatsD client running, see the STATSD_URL configuration op
 
 ```
 heroku buildpacks:add heroku/go
-heroku config:set HEROKU_APP_NAME=$(heroku apps:info|grep ===|cut -d' ' -f2)
 ```
 
 Don't forget [set right golang version](https://devcenter.heroku.com/articles/go-support#go-versions).

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Funnel metrics from multiple Heroku apps into DataDog using statsd.
 ### Clone the Github repository
 
 ```bash
-git clone git@github.com:apiaryio/heroku-datadog-drain-golang.git
+git clone git@github.com:busbud/heroku-datadog-drain-golang.git
 cd heroku-datadog-drain-golang
 ```
 
-### Setup Heroku, specify the app(s) you'll be monitoring and create a password for each.
+### Setup Heroku, add your statsd url and basic auth creds
 
 ```
 heroku create
-heroku config:set ALLOWED_APPS=<your-app-slug> <YOUR-APP-SLUG>_PASSWORD=<password>
+heroku config:set BASIC_AUTH_USERNAME=user BASIC_AUTH_PASSWORD=pass STATSD_URL=somewhere.com
 ```
 
 > **OPTIONAL**: Setup Heroku build packs, including the Datadog DogStatsD client.
@@ -36,15 +36,13 @@ If you already have a StatsD client running, see the STATSD_URL configuration op
 
 ```
 heroku buildpacks:add heroku/go
-heroku buildpacks:add --index 1 https://github.com/miketheman/heroku-buildpack-datadog.git
 heroku config:set HEROKU_APP_NAME=$(heroku apps:info|grep ===|cut -d' ' -f2)
-heroku config:add DATADOG_API_KEY=<your-Datadog-API-key>
 ```
 
 Don't forget [set right golang version](https://devcenter.heroku.com/articles/go-support#go-versions).
 
 ```
-heroku config:add GOVERSION=go1.9
+heroku config:add GOVERSION=go1.10
 ```
 
 ### Deploy to Heroku.
@@ -57,22 +55,18 @@ heroku ps:scale web=1
 ### Add the Heroku log drain using the app slug and password created above.
 
 ```
-heroku drains:add https://<your-app-slug>:<password>@<this-log-drain-app-slug>.herokuapp.com/ --app <your-app-slug>
+heroku drains:add https://<username>:<password>@<this-log-drain-app-slug>.herokuapp.com?app=<your-app-slug> --app <your-app-slug>
 ```
 
 ## Configuration
 ```bash
 STATSD_URL=..             # Required. Set to: localhost:8125
-DATADOG_API_KEY=...       # Required. Datadog API Key - https://app.datadoghq.com/account/settings#api
-ALLOWED_APPS=my-app,..    # Required. Comma seperated list of app names
-<APP-NAME>_PASSWORD=..    # Required. One per allowed app where <APP-NAME> corresponds to an app name from ALLOWED_APPS
-<APP-NAME>_TAGS=mytag,..  # Optional. Comma seperated list of default tags for each app
-<APP-NAME>_PREFIX=..      # Optional. String to be prepended to all metrics from a given app
+DATADOG_API_KEY=...       # Required if STATSD_URL is not set. Datadog API Key - https://app.datadoghq.com/account/settings#api
+BASIC_AUTH_USERNAME=...   # Required. Basic auth username to access drain.
+BASIC_AUTH_USERNAME=...   # Required. Basic auth password to access drain.
 DATADOG_DRAIN_DEBUG=..    # Optional. If DEBUG is set, a lot of stuff will be logged :)
 EXCLUDED_TAGS: path,host  # Optional. Recommended to solve problem with tags limit (1000)
 ```
-Note that the capitalized `<APP-NAME>` and `<YOUR-APP-SLUG>` appearing above indicate that your application name and slug should also be in full caps. For example, to set the password for an application named `my-app`, you would need to specify `heroku config:set ALLOWED_APPS=my-app MY-APP_PASSWORD=example_password`
-
 The rationale for `EXCLUDED_TAGS` is that the `path=` tag in Heroku logs includes the full HTTP path - including, for instance, query parameters. This makes very easy to swarm Datadog with numerous distinct tag/value pairs; and Datadog has a hard limit of 1000 such distinct pairs. When the limit is breached, they blacklist the entire metric.
 
 ## Heroku settings
@@ -94,7 +88,7 @@ app web.1 - info: responseLogger: metric#tag#route=/parser metric#request_id=117
 ```
 We support:
 
- * `metric#` and `sample#` for gauges 
+ * `metric#` and `sample#` for gauges
  * `metric#tag` for tags.
  * `count#` for counter increments
  * `measure#` for histograms

--- a/client.go
+++ b/client.go
@@ -50,13 +50,6 @@ func (c *Client) sendToStatsd(in chan *logMetrics) {
 			return
 		}
 
-		log.WithFields(log.Fields{
-			"type":   data.typ,
-			"app":    data.app,
-			"tags":   data.tags,
-			"prefix": data.prefix,
-		}).Debug("logMetrics received")
-
 		if data.typ == routerMsg {
 			c.sendRouterMsg(data)
 		} else if data.typ == sampleMsg {
@@ -113,13 +106,6 @@ func addStatusFamilyToTags(data *logMetrics, tags []string) []string {
 func (c *Client) sendRouterMsg(data *logMetrics) {
 	tags := c.extractTags(*data.tags, routerMetricsKeys, data.metrics)
 	tags = addStatusFamilyToTags(data, tags)
-
-	log.WithFields(log.Fields{
-		"app":    *data.app,
-		"tags":   *data.tags,
-		"prefix": *data.prefix,
-	}).Debug("sendRouterMsg")
-
 	conn, err := strconv.ParseFloat(data.metrics["connect"].Val, 10)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -158,12 +144,6 @@ func (c *Client) sendRouterMsg(data *logMetrics) {
 func (c *Client) sendSampleMsg(data *logMetrics) {
 	tags := c.extractTags(*data.tags, sampleMetricsKeys, data.metrics)
 
-	log.WithFields(log.Fields{
-		"app":    *data.app,
-		"tags":   tags,
-		"prefix": *data.prefix,
-	}).Debug("sendSampleMsg")
-
 	for k, v := range data.metrics {
 		if strings.Index(k, "#") != -1 {
 			m := strings.Replace(strings.Split(k, "#")[1], "_", ".", -1)
@@ -186,12 +166,6 @@ func (c *Client) sendSampleMsg(data *logMetrics) {
 
 func (c *Client) sendScalingMsg(data *logMetrics) {
 	tags := *data.tags
-
-	log.WithFields(log.Fields{
-		"app":    *data.app,
-		"tags":   tags,
-		"prefix": *data.prefix,
-	}).Debug("sendScalingMsg")
 
 	for _, mk := range scalingMetricsKeys {
 		if v, ok := data.metrics[mk]; ok {
@@ -243,12 +217,6 @@ Tags:
 		}
 	}
 
-	log.WithFields(log.Fields{
-		"app":    *data.app,
-		"tags":   tags,
-		"prefix": *data.prefix,
-	}).Debug("sendMetricTag")
-
 	for k, v := range data.metrics {
 		if strings.Index(k, "#") != -1 {
 			if vnum, err := strconv.ParseFloat(v.Val, 10); err == nil {
@@ -259,12 +227,6 @@ Tags:
 				if err != nil {
 					log.WithField("error", err).Warning("Failed to send Gauge")
 				}
-			} else {
-				log.WithFields(log.Fields{
-					"type":   "metrics",
-					"metric": k,
-					"err":    err,
-				}).Debug("Could not parse metric value")
 			}
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	statsd "github.com/DataDog/datadog-go/statsd"
-	log "github.com/Sirupsen/logrus"
-	"strconv"
-	"strings"
 	"errors"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
+
+	statsd "github.com/DataDog/datadog-go/statsd"
+	log "github.com/Sirupsen/logrus"
 )
 
 const sampleRate = 1.0
@@ -55,7 +56,6 @@ func (c *Client) sendToStatsd(in chan *logMetrics) {
 			"tags":   data.tags,
 			"prefix": data.prefix,
 		}).Debug("logMetrics received")
-
 
 		if data.typ == routerMsg {
 			c.sendRouterMsg(data)
@@ -214,10 +214,14 @@ func (c *Client) sendScalingMsg(data *logMetrics) {
 
 func (c *Client) sendMetric(metricType string, metricName string, value float64, tags []string) error {
 	switch metricType {
-	case "metric", "sample": return c.Gauge(metricName, value, tags, sampleRate)
-	case "measure": return c.Histogram(metricName, value, tags, sampleRate)
-	case "count": return c.Count(metricName, int64(value), tags, sampleRate)
-	default: return errors.New("Unknown metric type"+metricType)
+	case "metric", "sample":
+		return c.Gauge(metricName, value, tags, sampleRate)
+	case "measure":
+		return c.Histogram(metricName, value, tags, sampleRate)
+	case "count":
+		return c.Count(metricName, int64(value), tags, sampleRate)
+	default:
+		return errors.New("Unknown metric type" + metricType)
 	}
 }
 
@@ -251,7 +255,7 @@ Tags:
 				keySplit := strings.Split(k, "#")
 				metricType := keySplit[0]
 				m := strings.Replace(keySplit[1], "_", ".", -1)
-				err = c.sendMetric(metricType, *data.prefix+"app.metric."+m, vnum, tags)
+				err = c.sendMetric(metricType, *data.prefix+"heroku.metric."+m, vnum, tags)
 				if err != nil {
 					log.WithField("error", err).Warning("Failed to send Gauge")
 				}

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/apiaryio/heroku-datadog-drain-golang
+package: github.com/busbud/heroku-datadog-drain-golang
 import:
 - package: github.com/DataDog/datadog-go
   version: ^1.0.0

--- a/logproc.go
+++ b/logproc.go
@@ -51,7 +51,7 @@ func isDigit(r rune) bool {
 func parseMetrics(typ int, ld *logData, data *string, out chan *logMetrics) {
 	var myslice []string
 	lm := logMetrics{typ, ld.app, ld.tags, ld.prefix, make(map[string]logValue, 5), myslice}
-;
+
 	if typ == releaseMsg {
 		events := append(lm.events, *data)
 		lm.events = events
@@ -85,7 +85,7 @@ func parseScalingMessage(ld *logData, message *string, out chan *logMetrics) {
 			dynoType := dynoInfo[3]
 			log.WithFields(log.Fields{
 				"dynoName": dynoName,
-				"count": count,
+				"count":    count,
 				"dynoType": dynoType,
 			}).Debug()
 			logValues[dynoName] = logValue{count, dynoType}
@@ -95,7 +95,7 @@ func parseScalingMessage(ld *logData, message *string, out chan *logMetrics) {
 		out <- &lm
 	} else {
 		log.WithFields(log.Fields{
-			"err": "Scaling message not matched",
+			"err":     "Scaling message not matched",
 			"message": *message,
 		}).Warn()
 	}

--- a/logproc.go
+++ b/logproc.go
@@ -34,12 +34,6 @@ func (lm *logMetrics) HandleLogfmt(key, val []byte) error {
 		lm.metrics[string(key)] = logValue{string(val[:i+1]), string(val[i+1:])}
 	}
 
-	log.WithFields(log.Fields{
-		"key":  string(key),
-		"val":  lm.metrics[string(key)].Val,
-		"unit": lm.metrics[string(key)].Unit,
-	}).Debug("logMetric")
-
 	return nil
 }
 
@@ -83,11 +77,6 @@ func parseScalingMessage(ld *logData, message *string, out chan *logMetrics) {
 			dynoName := dynoInfo[1]
 			count := dynoInfo[2]
 			dynoType := dynoInfo[3]
-			log.WithFields(log.Fields{
-				"dynoName": dynoName,
-				"count":    count,
-				"dynoType": dynoType,
-			}).Debug()
 			logValues[dynoName] = logValue{count, dynoType}
 		}
 		events := []string{*message}

--- a/logproc.go
+++ b/logproc.go
@@ -101,7 +101,6 @@ func logProcess(in chan *logData, out chan *logMetrics) {
 			return
 		}
 
-		log.Debugln(*data.line)
 		output := strings.Split(*data.line, " - ")
 		if len(output) < 2 {
 			continue
@@ -112,7 +111,6 @@ func logProcess(in chan *logData, out chan *logMetrics) {
 		}
 		headers = headers[3:6]
 
-		log.WithField("headers", headers).Debug("Line headers")
 		if headers[1] == "heroku" {
 			if headers[2] == "router" {
 				parseMetrics(routerMsg, data, &output[1], out)

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gin-gonic/gin"
@@ -32,19 +33,6 @@ type ServerCtx struct {
 	in                chan *logData
 	out               chan *logMetrics
 }
-
-//Load configuration from envrionment variables, see list below
-//ALLOWED_APPS=my-app,.. Required.
-//Comma seperated list of app names
-
-//<APP-NAME>_PASSWORD=.. Required.
-//One per allowed app where <APP-NAME> corresponds to an app name from ALLOWED_APPS
-
-//<APP-NAME>_TAGS=mytag,..  Optional.
-// Comma seperated list of default tags for each app
-
-//<APP-NAME>_PREFIX=yee     Optional.
-//String to be prepended to all metrics from a given app
 
 //STATSD_URL=..  Required. Default: localhost:8125
 //DATADOG_DRAIN_DEBUG=         Optional. If DEBUG is set, a lot of stuff w
@@ -175,5 +163,4 @@ func main() {
 	go c.sendToStatsd(s.out)
 	log.Infoln("Server ready ...")
 	r.Run(":" + s.Port)
-
 }

--- a/server.go
+++ b/server.go
@@ -161,6 +161,15 @@ func main() {
 	defer close(s.out)
 	go logProcess(s.in, s.out)
 	go c.sendToStatsd(s.out)
+
+	go func() {
+		for {
+			c.Gauge("heroku_logdrain.queue.in.length", float64(len(s.in)), []string{}, sampleRate)
+			c.Gauge("heroku_logdrain.queue.out.length", float64(len(s.out)), []string{}, sampleRate)
+			time.Sleep(10 * time.Second)
+		}
+	}()
+
 	log.Infoln("Server ready ...")
 	r.Run(":" + s.Port)
 }

--- a/server.go
+++ b/server.go
@@ -115,7 +115,6 @@ func (s *ServerCtx) processLogs(c *gin.Context) {
 	scanner := bufio.NewScanner(c.Request.Body)
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.WithField("line", line).Debug("LINE")
 		s.in <- &logData{&app, &tags, &prefix, &line}
 	}
 	if err := scanner.Err(); err != nil {

--- a/server.go
+++ b/server.go
@@ -144,7 +144,8 @@ func main() {
 		}
 	}
 
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.Recovery())
 	r.GET("/status", func(c *gin.Context) {
 		c.String(200, "OK")
 	})

--- a/server_test.go
+++ b/server_test.go
@@ -99,8 +99,6 @@ func basicAuth(username, password string) string {
 func TestLogRequest(t *testing.T) {
 
 	s := loadServerCtx()
-	s.AllowedApps = append(s.AllowedApps, "test")
-	s.AppPasswd["test"] = "pass"
 
 	s.in = make(chan *logData)
 	defer close(s.in)
@@ -110,7 +108,9 @@ func TestLogRequest(t *testing.T) {
 	go logProcess(s.in, s.out)
 
 	r := gin.New()
-	auth := r.Group("/", gin.BasicAuth(s.AppPasswd))
+	accounts := map[string]string{}
+	accounts["test"] = "pass"
+	auth := r.Group("/", gin.BasicAuth(accounts))
 	auth.POST("/", s.processLogs)
 
 	req, _ := http.NewRequest("POST", "/", bytes.NewBuffer([]byte("LINE of text\nAnother line\n")))
@@ -135,8 +135,6 @@ func TestLogRequest(t *testing.T) {
 func TestFull(t *testing.T) {
 
 	s := loadServerCtx()
-	s.AllowedApps = append(s.AllowedApps, "test")
-	s.AppPasswd["test"] = "pass"
 
 	s.in = make(chan *logData)
 	defer close(s.in)
@@ -164,7 +162,9 @@ func TestFull(t *testing.T) {
 	go c.sendToStatsd(s.out)
 
 	r := gin.New()
-	auth := r.Group("/", gin.BasicAuth(s.AppPasswd))
+	accounts := map[string]string{}
+	accounts["test"] = "pass"
+	auth := r.Group("/", gin.BasicAuth(accounts))
 	auth.POST("/", s.processLogs)
 
 	data := make([]byte, 1024)


### PR DESCRIPTION
## Overview

This repo is a fork of the [heroku-datadog-drain-golang](https://github.com/apiaryio/heroku-datadog-drain-golang) written by ApiaryIO, with some minor changes so it can be used the way I prefer.

- Replaced `APPROVED_APPS` with basic auth and an `app` query string parameter.
- Removed app password, as we have basic auth.
- Make `STATSD_URL` a required config parameter.
- Automatically add `app` to tags for every metric
- Have all metrics prefixed with `heroku.` instead of `app.`.
- Adds channel length metrics
- Removes useless logrus calls
- Disables gin logger
- Formatting.